### PR TITLE
Fix config file not being read

### DIFF
--- a/src/nativeStub.m
+++ b/src/nativeStub.m
@@ -105,8 +105,18 @@ int main(int argc, char** argv) {
         }
 
         jvmVersion = javaInfo[@"JVMVersion"];
-        jvmOptionsFile = javaInfo[@"JVMOptionsFile"];
-        bootstrapScript = javaInfo[@"BootstrapScript"];
+        if(javaInfo[@"JVMOptionsFile"] != nil) {
+            NSString *jvmOptFileWithPlaceholders = javaInfo[@"JVMOptionsFile"];
+            jvmOptionsFile = resolvePlaceholders(jvmOptFileWithPlaceholders, javaFolder);
+        } else {
+            jvmOptionsFile = info[@"JVMOptionsFile"];
+        }
+        if(javaInfo[@"BootstrapScript"] != nil) {
+            NSString *bootstrapFileWithPlaceholders = javaInfo[@"BootstrapScript"];
+            bootstrapScript = resolvePlaceholders(bootstrapFileWithPlaceholders, javaFolder);
+        } else {
+            bootstrapScript = info[@"BootstrapScript"];
+        }
     } else {
         NSLog(@"[%s] [PlistStyle] Oracle", appName);
         javaFolder = [[main bundlePath] stringByAppendingPathComponent:@"Contents/Java"];
@@ -151,8 +161,18 @@ int main(int argc, char** argv) {
         }
 
         jvmVersion = info[@"JVMVersion"];
-        jvmOptionsFile = info[@"JVMOptionsFile"];
-        bootstrapScript = info[@"BootstrapScript"];
+        if(javaInfo[@"JVMOptionsFile"] != nil) {
+            NSString *jvmOptFileWithPlaceholders = javaInfo[@"JVMOptionsFile"];
+            jvmOptionsFile = resolvePlaceholders(jvmOptFileWithPlaceholders, javaFolder);
+        } else {
+            jvmOptionsFile = info[@"JVMOptionsFile"];
+        }
+        if(javaInfo[@"BootstrapScript"] != nil) {
+            NSString *bootstrapFileWithPlaceholders = javaInfo[@"BootstrapScript"];
+            bootstrapScript = resolvePlaceholders(bootstrapFileWithPlaceholders, javaFolder);
+        } else {
+            bootstrapScript = info[@"BootstrapScript"];
+        }
     }
     if([jvmVersion containsString:@";"]) {
         NSArray *stringParts = [jvmVersion componentsSeparatedByString:@";"];
@@ -360,6 +380,10 @@ int main(int argc, char** argv) {
         NSString *optionsFile = [[NSString alloc] initWithData:[fileManager contentsAtPath:jvmOptionsFile] encoding:NSUTF8StringEncoding];
         NSArray *lines = [optionsFile componentsSeparatedByString:@"\n"];
         for(NSString *line in lines) {
+            // Filter empty lines, otherwise application will fail to start for empty file
+            if ([line length] == 0) {
+                continue;
+            }
             if([line hasPrefix:@"#"]) {
                 continue;
             }

--- a/src/nativeStub.m
+++ b/src/nativeStub.m
@@ -471,7 +471,14 @@ NSString *fetchJavaVersion(NSString *path) {
     NSString *result = execute(path, @[@"-version"]);
     // The actual version will be between the first two quotes in the result
     // We can reasonably ignore all the rest of the output
-    return [result componentsSeparatedByString:@"\""][1];
+    NSArray *components = [result componentsSeparatedByString:@"\""];
+	if (components.count > 1) {
+		return components[1];
+	} else {
+		// Handle unexpected format
+		NSLog(@"Error: Unexpected version string format: %@", result);
+		return nil;
+	}
 }
 
 NSString *normalizeJavaVersion(NSString *version) {


### PR DESCRIPTION
The current native launcher does not resolve placeholders for the jvmOptionsFile, leading to the options never being loaded.

The empty string filtering in the options loading code is a workaround for an issue I don't fully understand, where if missing and an empty options file is present the application will fail to start  though the generated java command that is executed seems to be correct.

The bootstrap file seems to also suffer from a placeholder issue, so I have updated that as well.